### PR TITLE
[patch-axel-29] make macro less obscure

### DIFF
--- a/include/kernel/boot.h
+++ b/include/kernel/boot.h
@@ -18,7 +18,7 @@
 typedef cte_t  slot_t;
 typedef cte_t *slot_ptr_t;
 #define SLOT_PTR(pptr, pos) (((slot_ptr_t)(pptr)) + (pos))
-#define pptr_of_cap (pptr_t)cap_get_capPtr
+#define pptr_of_cap(cap) ((pptr_t)cap_get_capPtr(cap))
 
 /* (node-local) state accessed only during bootstrapping */
 


### PR DESCRIPTION
- explicitly mention the parameter to make macro less obscure.
- add brackets to make the expression an atom.

Signed-off-by: Axel Heider <axel.heider@hensoldt.net>