### PR TITLE
aarch32: fix define check

### DIFF
--- a/include/arch/arm/arch/32/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/32/mode/fastpath/fastpath.h
@@ -118,7 +118,7 @@ static inline void NORETURN FORCE_INLINE fastpath_restore(word_t badge, word_t m
 
     c_exit_hook();
 
-#ifdef CONFIG_ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
+#ifdef ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS
     restore_user_debug_context(NODE_STATE(ksCurThread));
 #endif
 


### PR DESCRIPTION
Fix wrong name used in refactoring of commit 4b491dcf

`include/arch/arm/arch/machine/debug_conf.h`defines `ARM_CP14_SAVE_AND_RESTORE_NATIVE_THREADS`

This change does what `restore_user_context()` does.

I have found this in a code review, but not tested this feature. Has anybody a setup that uses this?