### PR TITLE
risc-v: remove K constraint in fcsr access wrapper

### DIFF
--- a/include/arch/riscv/arch/machine.h
+++ b/include/arch/riscv/arch/machine.h
@@ -218,7 +218,7 @@ static inline uint32_t read_fcsr(void)
 
 static inline void write_fcsr(uint32_t value)
 {
-    asm volatile("csrw fcsr, %0" :: "rK"(value));
+    asm volatile("csrw fcsr, %0" :: "r"(value));
 }
 #endif
 


### PR DESCRIPTION
The 'K' constraint is for 5-bit unsigned integer immediate operands only in both GCC and LLVM. It does not apply to the value written.

See manual:
- https://llvm.org/docs/LangRef.html#supported-constraint-code-list
- https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html

In the Linux kernek there is this commit that adds the 'K' constraint, which might explain the origin. But I think this is incorrect usage.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/arch/riscv/include/asm/csr.h?id=a3182c91ef4e7dda90ff080a4132efd3ecb8786a
