### PR TITLE
[patch-axel-57] add seL4_DebugNameThreadFmt()

### DIFF
--- a/include/api/debug.h
+++ b/include/api/debug.h
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#pragma once
+
 #include <config.h>
 
 #ifdef CONFIG_DEBUG_BUILD
-#pragma once
 
 #include <benchmark/benchmark_track.h>
 #include <arch/api/syscall.h>

--- a/libsel4/arch_include/arm/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/arm/sel4/arch/syscalls.h
@@ -629,10 +629,14 @@ LIBSEL4_INLINE_FUNC seL4_Uint32 seL4_DebugCapIdentify(seL4_CPtr cap)
     return (seL4_Uint32)cap;
 }
 
-char *strcpy(char *, const char *);
+char *strncpy(char *, const char *, seL4_Word);
 LIBSEL4_INLINE_FUNC void seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
-    strcpy((char *)seL4_GetIPCBuffer()->msg, name);
+    /* IPC buffer can be used directly, otherwise buffers must not overlap. */
+    char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg;
+    if (name != ipc_buf) {
+        strncpy(ipc_buf, name, seL4_MsgMaxLength);
+    }
 
     seL4_Word unused0 = 0;
     seL4_Word unused1 = 0;

--- a/libsel4/arch_include/riscv/sel4/arch/syscalls.h
+++ b/libsel4/arch_include/riscv/sel4/arch/syscalls.h
@@ -834,10 +834,14 @@ LIBSEL4_INLINE_FUNC seL4_Uint32 seL4_DebugCapIdentify(seL4_CPtr cap)
     return (seL4_Uint32)cap;
 }
 
-char *strcpy(char *, const char *);
+char *strncpy(char *, const char *, seL4_Word);
 LIBSEL4_INLINE_FUNC void seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
-    strcpy((char *)seL4_GetIPCBuffer()->msg, name);
+    /* IPC buffer can be used directly, otherwise buffers must not overlap. */
+    char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg;
+    if (name != ipc_buf) {
+        strncpy(ipc_buf, name, seL4_MsgMaxLength);
+    }
 
     seL4_Word unused0 = 0;
     seL4_Word unused1 = 0;

--- a/libsel4/include/sel4/functions.h
+++ b/libsel4/include/sel4/functions.h
@@ -103,3 +103,24 @@ LIBSEL4_INLINE_FUNC void seL4_SetCapReceivePath(seL4_CPtr receiveCNode, seL4_CPt
     ipcbuffer->receiveDepth = receiveDepth;
 }
 
+#if CONFIG_DEBUG_BUILD
+
+/* Making this a macro avoids requiring stdarg.h to get va_start() */
+#define seL4_DebugNameThreadFmt(tcb, fmt, ...) \
+    do { \
+        char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg; \
+        snprintf(ipc_buf, seL4_MsgMaxLength, fmt, __VA_ARGS__); \
+        seL4_DebugNameThread(tcb, ipc_buf); \
+    } while(0)
+
+// LIBSEL4_INLINE_FUNC void seL4_DebugNameThreadFmt(seL4_CPtr tcb, const char *fmt, ...)
+// {
+//     char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg;
+//     va_list args;
+//     va_start(args, fmt);
+//     vsnprintf(ipc_buf, seL4_MsgMaxLength, fmt, args)
+//     va_end(args);
+//     seL4_DebugNameThread(tcb, ipc_buf);
+// }
+
+#endif /* CONFIG_DEBUG_BUILD */

--- a/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/ia32/sel4/sel4_arch/syscalls.h
@@ -862,10 +862,14 @@ LIBSEL4_INLINE_FUNC seL4_Uint32 seL4_DebugCapIdentify(seL4_CPtr cap)
     return (seL4_Uint32)cap;
 }
 
-char *strcpy(char *, const char *);
+char *strncpy(char *, const char *, seL4_Word);
 LIBSEL4_INLINE_FUNC void seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
-    strcpy((char *)seL4_GetIPCBuffer()->msg, name);
+    /* IPC buffer can be used directly, otherwise buffers must not overlap. */
+    char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg;
+    if (name != ipc_buf) {
+        strncpy(ipc_buf, name, seL4_MsgMaxLength);
+    }
 
     seL4_Word unused0 = 0;
     seL4_Word unused1 = 0;

--- a/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
+++ b/libsel4/sel4_arch_include/x86_64/sel4/sel4_arch/syscalls.h
@@ -658,11 +658,14 @@ LIBSEL4_INLINE_FUNC seL4_Uint32 seL4_DebugCapIdentify(seL4_CPtr cap)
 #endif
 
 #ifdef CONFIG_DEBUG_BUILD
-char *strcpy(char *, const char *);
+char *strncpy(char *, const char *, seL4_Word);
 LIBSEL4_INLINE_FUNC void seL4_DebugNameThread(seL4_CPtr tcb, const char *name)
 {
-
-    strcpy((char *)seL4_GetIPCBuffer()->msg, name);
+    /* IPC buffer can be used directly, otherwise buffers must not overlap. */
+    char *ipc_buf = (char *)seL4_GetIPCBuffer()->msg;
+    if (name != ipc_buf) {
+        strncpy(ipc_buf, name, seL4_MsgMaxLength);
+    }
 
     seL4_Word unused0 = 0;
     seL4_Word unused1 = 0;


### PR DESCRIPTION
This is a convenient way to create thread names dynamically. Also change seL4_DebugNameThread() to use strncpy() instead of  strcpy() to honor the IPC buffer size.

Inspired by https://github.com/seL4/seL4_projects_libs/pull/77

```
seL4_DebugNameThreadFmt(tcb, "%s:%d", vm->vm_name, vcpu->vcpu_id););
```