### PR TITLE
boot: introduce seL4_BootInfoFrameSize

### DIFF
--- a/include/bootinfo.h
+++ b/include/bootinfo.h
@@ -16,10 +16,4 @@
 
 #define S_REG_EMPTY (seL4_SlotRegion){ .start = 0, .end = 0 }
 
-/* The boot info frame takes at least one page, it must be big enough to hold
- * the seL4_BootInfo data structure. Due to internal restrictions, the boot info
- * frame size must be of the form 2^n. Furthermore, there might still be code
- * that makes the hard-coded assumption the boot info frame is always one page.
- */
-#define BI_FRAME_SIZE_BITS PAGE_BITS
-compile_assert(bi_size, sizeof(seL4_BootInfo) <= BIT(BI_FRAME_SIZE_BITS))
+#define BI_FRAME_SIZE_BITS seL4_BootInfoFrameBits

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -8,6 +8,7 @@
 
 #include <autoconf.h>
 #include <sel4/macros.h>
+#include <sel4/sel4_arch/constants.h>
 
 /* caps with fixed slot positions in the root CNode */
 enum {
@@ -79,11 +80,26 @@ typedef struct seL4_BootInfo {
      * to make this struct easier to represent in other languages */
 } seL4_BootInfo;
 
-/* If extraLen > 0, then 4K after the start of bootinfo there is a region of the
- * size extraLen that contains additional boot info data chunks. They are
- * arch/platform specific and may or may not exist in any given execution. Each
- * chunk has a header that contains an ID to describe the chunk. All IDs share a
- * global namespace to ensure uniqueness.
+/* The boot info frame must be large enough to hold the seL4_BootInfo data
+ * structure. Due to internal restrictions, the size must be of the form 2^n and
+ * the minimum is one page.
+ */
+#define seL4_BootInfoFrameBits  seL4_PageBits
+#define seL4_BootInfoFrameSize  LIBSEL4_BIT(seL4_BootInfoFrameBits)
+
+SEL4_COMPILE_ASSERT(
+    invalid_seL4_BootInfoFrameSize,
+    sizeof(seL4_BootInfo) <= seL4_BootInfoFrameSize)
+
+/* If seL4_BootInfo.extraLen > 0, this indicate the presence of additional boot
+ * information chunks starting at the offset SEL4_BI_FRAME_SIZE. Note that since
+ * x86, Arm and RISC-V use 4 KiByte pages and the boot info frame usually is one
+ * page, legacy userland code often contains the hard-coded assumption, that
+ * this offset is 4 KiByte instead of using SEL4_BI_FRAME_SIZE. Unfortunately,
+ * seL4_BootInfo currently has no field that allows passing this offset.
+ * The additional boot is arch/platform specific, it may or may not exist in any
+ * given execution. Each chunk has a header that contains an ID to describe the
+ * chunk. All IDs share a global namespace to ensure uniqueness.
  */
 typedef enum {
     SEL4_BOOTINFO_HEADER_PADDING            = 0,

--- a/manual/parts/bootup.tex
+++ b/manual/parts/bootup.tex
@@ -118,14 +118,15 @@ of slots in the initial thread's CNode, starting with CPTR \texttt{start} and wi
   \end{center}
 \end{table}
 
-Depending on the architecture and platform there might be additional pieces of boot
-information. If \texttt{extraLen} is greater than zero, then 4K after the start of bootinfo
-is a region of extraLen bytes containing additional bootinfo structures. Each chunk starts
-with a \texttt{seL4\_BootInfoHeader}, described in \autoref{tab:bi_header_struct}, that
-describes what the chunk is and how long it is, where the length includes the header. The
-length can be used to skip over chunks that you do not understand. The only generally
-defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING} and describes an empty
-chunk that has no data, any other types are platform or architecture specific. The
+The size of the fixed Boot Info Frame is \texttt{seL4\_BootInfoFrameSize}. In the standard
+configuration, this is one page, which is 4 KiByte on x86, ARM and RISC-V. Depending on the
+architecture and platform, there might be additional pieces of variable boot information
+following afterwards. The overall size of this data is \texttt{extraLen}, it contains a
+sequence of blobs, where each one start with a \texttt{seL4\_BootInfoHeader} described in
+\autoref{tab:bi_header_struct}. This header describes what the blob is and how long it is,
+where the length includes the header. Thus, the length can be used to skip over unknown
+chunks. The only generally defined chunk type is \texttt{SEL4\_BOOTINFO\_HEADER\_PADDING}
+and describes a blob where any payload data exists for padding only. The
 \texttt{extraBIPages} slot region gives the frames capabilities for the pages that make up
 the additional boot info region.
 

--- a/src/kernel/boot.c
+++ b/src/kernel/boot.c
@@ -208,6 +208,10 @@ BOOT_CODE static void create_rootserver_objects(pptr_t start, v_region_t it_v_re
     compile_assert(invalid_seL4_ASIDPoolBits, seL4_ASIDPoolBits == seL4_PageBits);
     rootserver.asid_pool = alloc_rootserver_obj(seL4_ASIDPoolBits, 1);
     rootserver.ipc_buf = alloc_rootserver_obj(seL4_PageBits, 1);
+    /* The boot info size must be at least one page. Due to the hard-coded order
+     * of allocations used in the current implementation here, it can't be any
+     * bigger,
+     */
     compile_assert(invalid_BI_FRAME_SIZE_BITS, BI_FRAME_SIZE_BITS == seL4_PageBits);
     rootserver.boot_info = alloc_rootserver_obj(BI_FRAME_SIZE_BITS, 1);
 


### PR DESCRIPTION
Provide seL4_BootInfoFrameSize (and seL4_BootInfoFrameBits) for userland, to there is no longer a need to hard-code the 4 KiByte assumption.